### PR TITLE
Fix double-quoted into receiver string

### DIFF
--- a/smtp/send_mail_resource.go
+++ b/smtp/send_mail_resource.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/smtp"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -176,7 +177,9 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 	for _, addr := range receivers {
-		err = conn.Rcpt(addr.String())
+		var receiver, _ = strconv.Unquote(addr.String())
+		tflog.Debug(ctx, "Receiver: "+receiver)
+		err = conn.Rcpt(receiver)
 		if err != nil {
 			resp.Diagnostics.AddError("Error setting recipient address:", err.Error())
 			return
@@ -276,7 +279,9 @@ func (r *sendMailResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 	for _, addr := range receivers {
-		err = conn.Rcpt(addr.String())
+		var receiver, _ = strconv.Unquote(addr.String())
+		tflog.Debug(ctx, "Receiver: "+receiver)
+		err = conn.Rcpt(receiver)
 		if err != nil {
 			resp.Diagnostics.AddError("Error setting recipient address:", err.Error())
 			return


### PR DESCRIPTION
Some SMTP servers return an error with the recipient address:
`501 <"to@example.com">: recipient address must contain a domain`

The recipient is put with double-quoted. This fix remove this double-quoted for the string of the recipient addresses