### PR TITLE
Fix issue with AWS SES SMTP servers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,5 +56,3 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  skip: true

--- a/smtp/send_mail_resource.go
+++ b/smtp/send_mail_resource.go
@@ -126,9 +126,9 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	host_port := r.client.host + ":" + r.client.port
+	hostPort := r.client.host + ":" + r.client.port
 	// Connect to the SMTP server using a plain TCP connection.
-	conn, err := smtp.Dial(host_port)
+	conn, err := smtp.Dial(hostPort)
 	if err != nil {
 		resp.Diagnostics.AddError("Error connecting to SMTP server:", err.Error())
 		return
@@ -136,7 +136,7 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 
 	// Upgrade the connection to TLS.
 	if r.client.auth != nil {
-		err = conn.StartTLS(&tls.Config{ServerName: host_port, InsecureSkipVerify: true})
+		err = conn.StartTLS(&tls.Config{ServerName: hostPort, InsecureSkipVerify: true})
 		if err != nil {
 			resp.Diagnostics.AddError("Error upgrading connection to TLS:", err.Error())
 			return
@@ -202,6 +202,7 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 	err = w.Close()
 	if err != nil {
 		resp.Diagnostics.AddError("Error sending email:", err.Error())
+		resp.Diagnostics.AddError("Email body:", string(msg[:]))
 		return
 	}
 
@@ -231,9 +232,9 @@ func (r *sendMailResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	host_port := r.client.host + ":" + r.client.port
+	hostPort := r.client.host + ":" + r.client.port
 	// Connect to the SMTP server using a plain TCP connection.
-	conn, err := smtp.Dial(host_port)
+	conn, err := smtp.Dial(hostPort)
 	if err != nil {
 		resp.Diagnostics.AddError("Error connecting to SMTP server:", err.Error())
 		return
@@ -241,7 +242,7 @@ func (r *sendMailResource) Update(ctx context.Context, req resource.UpdateReques
 
 	// Upgrade the connection to TLS.
 	if r.client.auth != nil {
-		err = conn.StartTLS(&tls.Config{ServerName: host_port, InsecureSkipVerify: true})
+		err = conn.StartTLS(&tls.Config{ServerName: hostPort, InsecureSkipVerify: true})
 		if err != nil {
 			resp.Diagnostics.AddError("Error upgrading connection to TLS:", err.Error())
 			return
@@ -346,9 +347,10 @@ func uniqueAttrValue(arr []attr.Value) []attr.Value {
 
 // Convert the array of attr.Value to  array of string.
 func asStringList(arr []attr.Value) []string {
-	result := []string{}
+	var result []string
 	for _, i := range arr {
-		result = append(result, i.String())
+		unquotedString, _ := strconv.Unquote(i.String())
+		result = append(result, unquotedString)
 	}
 	return result
 }

--- a/smtp/send_mail_resource.go
+++ b/smtp/send_mail_resource.go
@@ -202,7 +202,6 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 	err = w.Close()
 	if err != nil {
 		resp.Diagnostics.AddError("Error sending email:", err.Error())
-		resp.Diagnostics.AddError("Email body:", string(msg[:]))
 		return
 	}
 


### PR DESCRIPTION
## Problem Statement

When we try to use this provider with AWS SES SMTP servers to send emails, we encounter an error:

```
╷
│ Error: Error sending email:
│
│   with module.email_notifications[0].smtp_send_mail.this["example@example.com"],
│   on modules/email-notifications/main.tf line 15, in resource "smtp_send_mail" "this":
│   15: resource "smtp_send_mail" "this" {
│
│ 554 Transaction failed: Missing final '@domain'
╵
```

## Solution

It appears that AWS SES SMTP servers expect CC and TO addresses to be unquoted. Without changes in this PR, the provider sends an email with the following CC and TO:

```
│
│ To: "example@example.com"
│ Cc: "example@example.com"
│ Subject: Example
│ MIME-version: 1.0;
│ Content-Type: text/html; charset="UTF-8";
│
```

Such emails sent to AWS SES SMTP servers produce errors.

This PR adds unquoting for TO and CC email addresses. With unquoted addresses, AWS SES SMTP servers send emails without errors.