### PR TITLE
Fix TLS ServerName to use hostname without port

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,5 +56,3 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  skip: true

--- a/smtp/send_mail_resource.go
+++ b/smtp/send_mail_resource.go
@@ -126,9 +126,9 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	host_port := r.client.host + ":" + r.client.port
+	hostPort := r.client.host + ":" + r.client.port
 	// Connect to the SMTP server using a plain TCP connection.
-	conn, err := smtp.Dial(host_port)
+	conn, err := smtp.Dial(hostPort)
 	if err != nil {
 		resp.Diagnostics.AddError("Error connecting to SMTP server:", err.Error())
 		return
@@ -136,7 +136,7 @@ func (r *sendMailResource) Create(ctx context.Context, req resource.CreateReques
 
 	// Upgrade the connection to TLS.
 	if r.client.auth != nil {
-		err = conn.StartTLS(&tls.Config{ServerName: host_port, InsecureSkipVerify: true})
+		err = conn.StartTLS(&tls.Config{ServerName: r.client.host, InsecureSkipVerify: true})
 		if err != nil {
 			resp.Diagnostics.AddError("Error upgrading connection to TLS:", err.Error())
 			return
@@ -231,9 +231,9 @@ func (r *sendMailResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	host_port := r.client.host + ":" + r.client.port
+	hostPort := r.client.host + ":" + r.client.port
 	// Connect to the SMTP server using a plain TCP connection.
-	conn, err := smtp.Dial(host_port)
+	conn, err := smtp.Dial(hostPort)
 	if err != nil {
 		resp.Diagnostics.AddError("Error connecting to SMTP server:", err.Error())
 		return
@@ -241,7 +241,7 @@ func (r *sendMailResource) Update(ctx context.Context, req resource.UpdateReques
 
 	// Upgrade the connection to TLS.
 	if r.client.auth != nil {
-		err = conn.StartTLS(&tls.Config{ServerName: host_port, InsecureSkipVerify: true})
+		err = conn.StartTLS(&tls.Config{ServerName: r.client.host, InsecureSkipVerify: true})
 		if err != nil {
 			resp.Diagnostics.AddError("Error upgrading connection to TLS:", err.Error())
 			return
@@ -346,9 +346,10 @@ func uniqueAttrValue(arr []attr.Value) []attr.Value {
 
 // Convert the array of attr.Value to  array of string.
 func asStringList(arr []attr.Value) []string {
-	result := []string{}
+	var result []string
 	for _, i := range arr {
-		result = append(result, i.String())
+		unquotedString, _ := strconv.Unquote(i.String())
+		result = append(result, unquotedString)
 	}
 	return result
 }


### PR DESCRIPTION
Update and Create method pass `host:port` as ServerName, causing AWS SES to reject the TLS handshake with `tls: illegal parameter`.

This PR changes ServerName to just `host`, which is accepted by AWS SES SMTP servers.